### PR TITLE
Update: tech task now uses TCA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,62 @@
-# Bright iOS Technical Test
+# Tech Task: SwiftUI Implementation with TCA
 
-## The project: A Trivia Question App 
+## Background
+At BrightHR, for legacy features, we are using UIKit and for new features, we are using SwiftUI. We are in the process of migrating UIKit to SwiftUI. For SwiftUI, we are using a mixture of MVVM and the Composable Architecture (TCA).
 
-Ready to take on a fun challenge?  
-In this project, you'll create a simple trivia game app called 'Trivia Quest.' The app will test users' knowledge with a variety of questions. 
-You'll need to use your skills in Swift/SwiftUI to build an exciting and interactive trivia experience that will keep users hooked!
+For more info on TCA click [here](https://github.com/pointfreeco/swift-composable-architecture).
 
-We're interested in seeing the architecture you will implement for the codebase, the design patterns and the user experience. 
+## Task Description
+We've provided a skeleton project with a root view implemented using SwiftUI and TCA. Your task is to complete the implementation by addressing all TODOs in the codebase, which include:
 
-## The API
+1. Navigation Implementation:
 
-You will need to use the following endpoint from [Open Trivia DB](https://opentdb.com/api_config.php) API to complete the take home
-test:
+    - Create a navigation flow between Screens A, B, and C using SwiftUI's NavigationStack
+    - Implement "pop to root" functionality
 
-    GET https://opentdb.com/api.php?amount=15
+2. UI Presentations:
 
-All endpoints return a JSON response 
+    - Implement various presentation patterns:
+    - Confirmation dialogs
+    - Alerts
+    - Bottom sheets
+    - Full-screen covers
 
-## The Tasks
+3. TCA Implementation:
 
-### Task 1: Display Trivia Questions List
-
-Create a screen that retrieves trivia questions from the Open Trivia Database API and displays them in a list format.
-
-- Fetch 15 trivia questions from the API (https://opentdb.com/api.php?amount=15).
-- Display each question in a list view, showing the level of difficulty, category, and the question itself.
-
-### Task 2: Detailed Question Screen
-
-Implement a screen that displays full details of a selected question when tapped.
-
-- Upon tapping on a question from the list, navigate to a detailed screen.
-- Show the type, difficulty, category, question, correct answer, and incorrect answers.
-- Implement a self-explanatory UI indicator (ex. a badge) to distinguish between boolean and multiple-choice questions.
-
-### Task 3: Search functionality 
-
-Incorporate a search bar to allow users to search for specific questions based on keywords.
-
-- Implement a search bar to allow users to type in specific keywords for the search functionality.
-- Display search results questions that contains the search keyword typed in the search bar.
-Ex: the keyword was "how". Questions that contains the keyword "how" should be displayed in the results. 
-
-### Additional requirements 
-
-Upon returning to the main screen, indicate with a badge those questions for which the user has viewed details, to prevent unnecessary revisiting. 
-
-## BONUS 
-
-Provide the option to filter questions by difficulty level and/or category as a bonus feature
+    - Structure the application state properly
+    - Implement reducers for handling navigation logic
+    - Manage state transitions between screens
 
 ## Requirements
+- Navigation should be done using SwiftUI NavigationStack (not NavigationView)
+- Code should follow TCA patterns and best practices
+- Implementation should be complete for all TODOs in the codebase
+- Unit tests should be included for your implementation
+- Use the latest available version of TCA at the time of completing this task
 
-- Submission must have a good unit test coverage.
-- The project should build for iOS 16+.
-- UI should be written/convert into SwiftUI.
-- The project should build and run without warnings with latest Xcode.
-- The app should scale from the iPhone SE to the iPhone Pro Max.
-- Error handling should be considered.
-- You can use third party packages but be prepared to justify your
-  choices.
-- Write the code using MVVM or [composable architecture](https://pointfreeco.github.io/swift-composable-architecture/main/tutorials/meetcomposablearchitecture/). 
+## Build Tools
+
+| Tool           |                       Version |
+| :------------- | ----------------------------: |
+| iOS Target     |                          18.0 |
+| Swift          |                          6.0  |
+
+## Evaluation Criteria
+You will be assessed on:
+
+- SwiftUI knowledge
+- TCA implementation skills
+- Code structure and organization
+- Readability and effectiveness of unit tests
+
+## Estimated Time
+This task should take less than 3 hours to complete.
 
 ## Submission
 
-Please provide us a Github link to your submission. 
-Please commit regularly as you carry out the task and keep the commit history in tact. 
-We would love to see if you can devlop the feature using TDD.
+Please complete your implementation using the following steps:
 
-## Alternative
-
-If you have a good example project that demonstrates your coding skills, 
-you can choose to use that project for submission instead of working on the one above.
+1. Fork the repository
+3. Implement all the required features with meaningful commits that demonstrate your approach
+4. Once complete, push your implementation to your GitHub repository
+5. Submit the GitHub repository URL to the provided submission link/email

--- a/TechTask.xcodeproj/project.pbxproj
+++ b/TechTask.xcodeproj/project.pbxproj
@@ -1,0 +1,506 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		092D50B32D92AFB70094CA72 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 092D50B22D92AFB70094CA72 /* ComposableArchitecture */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		092D50952D92AF8D0094CA72 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 092D507B2D92AF8A0094CA72 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 092D50822D92AF8A0094CA72;
+			remoteInfo = TCAExamples;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		092D50832D92AF8A0094CA72 /* TechTask.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TechTask.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		092D50942D92AF8D0094CA72 /* TechTaskTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TechTaskTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		092D50852D92AF8A0094CA72 /* TechTask */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = TechTask;
+			sourceTree = "<group>";
+		};
+		092D50972D92AF8D0094CA72 /* TechTaskTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = TechTaskTests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		092D50802D92AF8A0094CA72 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				092D50B32D92AFB70094CA72 /* ComposableArchitecture in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		092D50912D92AF8D0094CA72 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		092D507A2D92AF8A0094CA72 = {
+			isa = PBXGroup;
+			children = (
+				092D50852D92AF8A0094CA72 /* TechTask */,
+				092D50972D92AF8D0094CA72 /* TechTaskTests */,
+				092D50842D92AF8A0094CA72 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		092D50842D92AF8A0094CA72 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				092D50832D92AF8A0094CA72 /* TechTask.app */,
+				092D50942D92AF8D0094CA72 /* TechTaskTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		092D50822D92AF8A0094CA72 /* TechTask */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 092D50A82D92AF8D0094CA72 /* Build configuration list for PBXNativeTarget "TechTask" */;
+			buildPhases = (
+				092D507F2D92AF8A0094CA72 /* Sources */,
+				092D50802D92AF8A0094CA72 /* Frameworks */,
+				092D50812D92AF8A0094CA72 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				092D50852D92AF8A0094CA72 /* TechTask */,
+			);
+			name = TechTask;
+			packageProductDependencies = (
+				092D50B22D92AFB70094CA72 /* ComposableArchitecture */,
+			);
+			productName = TCAExamples;
+			productReference = 092D50832D92AF8A0094CA72 /* TechTask.app */;
+			productType = "com.apple.product-type.application";
+		};
+		092D50932D92AF8D0094CA72 /* TechTaskTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 092D50AB2D92AF8D0094CA72 /* Build configuration list for PBXNativeTarget "TechTaskTests" */;
+			buildPhases = (
+				092D50902D92AF8D0094CA72 /* Sources */,
+				092D50912D92AF8D0094CA72 /* Frameworks */,
+				092D50922D92AF8D0094CA72 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				092D50962D92AF8D0094CA72 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				092D50972D92AF8D0094CA72 /* TechTaskTests */,
+			);
+			name = TechTaskTests;
+			packageProductDependencies = (
+			);
+			productName = TCAExamplesTests;
+			productReference = 092D50942D92AF8D0094CA72 /* TechTaskTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		092D507B2D92AF8A0094CA72 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1620;
+				LastUpgradeCheck = 1620;
+				TargetAttributes = {
+					092D50822D92AF8A0094CA72 = {
+						CreatedOnToolsVersion = 16.2;
+					};
+					092D50932D92AF8D0094CA72 = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = 092D50822D92AF8A0094CA72;
+					};
+				};
+			};
+			buildConfigurationList = 092D507E2D92AF8A0094CA72 /* Build configuration list for PBXProject "TechTask" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 092D507A2D92AF8A0094CA72;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				092D50B12D92AFB70094CA72 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 092D50842D92AF8A0094CA72 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				092D50822D92AF8A0094CA72 /* TechTask */,
+				092D50932D92AF8D0094CA72 /* TechTaskTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		092D50812D92AF8A0094CA72 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		092D50922D92AF8D0094CA72 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		092D507F2D92AF8A0094CA72 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		092D50902D92AF8D0094CA72 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		092D50962D92AF8D0094CA72 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 092D50822D92AF8A0094CA72 /* TechTask */;
+			targetProxy = 092D50952D92AF8D0094CA72 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		092D50A62D92AF8D0094CA72 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		092D50A72D92AF8D0094CA72 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		092D50A92D92AF8D0094CA72 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TechTask/TechTask.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"TechTask/Preview Content\"";
+				DEVELOPMENT_TEAM = 6265TAR63Y;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.brighthr.iOSTechTask;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				XROS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Debug;
+		};
+		092D50AA2D92AF8D0094CA72 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TechTask/TechTask.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"TechTask/Preview Content\"";
+				DEVELOPMENT_TEAM = 6265TAR63Y;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.brighthr.iOSTechTask;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				XROS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Release;
+		};
+		092D50AC2D92AF8D0094CA72 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6265TAR63Y;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.brighthr.iOSTechTask;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TechTask.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/TechTask";
+				XROS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Debug;
+		};
+		092D50AD2D92AF8D0094CA72 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6265TAR63Y;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.brighthr.iOSTechTask;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TechTask.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/TechTask";
+				XROS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		092D507E2D92AF8A0094CA72 /* Build configuration list for PBXProject "TechTask" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				092D50A62D92AF8D0094CA72 /* Debug */,
+				092D50A72D92AF8D0094CA72 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		092D50A82D92AF8D0094CA72 /* Build configuration list for PBXNativeTarget "TechTask" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				092D50A92D92AF8D0094CA72 /* Debug */,
+				092D50AA2D92AF8D0094CA72 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		092D50AB2D92AF8D0094CA72 /* Build configuration list for PBXNativeTarget "TechTaskTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				092D50AC2D92AF8D0094CA72 /* Debug */,
+				092D50AD2D92AF8D0094CA72 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		092D50B12D92AFB70094CA72 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-composable-architecture";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.19.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		092D50B22D92AFB70094CA72 /* ComposableArchitecture */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 092D50B12D92AFB70094CA72 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;
+			productName = ComposableArchitecture;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 092D507B2D92AF8A0094CA72 /* Project object */;
+}

--- a/TechTask/AppMain.swift
+++ b/TechTask/AppMain.swift
@@ -1,0 +1,16 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import ComposableArchitecture
+import SwiftUI
+
+@main
+struct AppMain: App {
+  var body: some Scene {
+    WindowGroup {
+      Root(store: Store(
+        initialState: RootLogic.State(),
+        reducer: { RootLogic() }
+      ))
+    }
+  }
+}

--- a/TechTask/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/TechTask/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TechTask/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TechTask/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,85 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TechTask/Assets.xcassets/Contents.json
+++ b/TechTask/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TechTask/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/TechTask/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TechTask/Root/Root.swift
+++ b/TechTask/Root/Root.swift
@@ -1,0 +1,43 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import ComposableArchitecture
+import SwiftUI
+
+struct Root: View {
+  let store: StoreOf<RootLogic>
+  var body: some View {
+    VStack(spacing: 10) {
+      Image(systemName: "globe")
+        .imageScale(.large)
+        .foregroundStyle(.tint)
+      Text("RootView")
+
+      VStack(spacing: 10) {
+        Spacer()
+        Button {
+          // TODO:
+        } label: {
+          Text("Navigate to Screen A")
+        }
+        Button {
+          // TODO:
+        } label: {
+          Text("Navigate to Screen B")
+        }
+        Button {
+          // TODO:
+        } label: {
+          Text("Navigate to Screen C")
+        }
+      }
+    }
+    .padding()
+  }
+}
+
+#Preview {
+  Root(store: Store(
+    initialState: RootLogic.State(),
+    reducer: { RootLogic() }
+  ))
+}

--- a/TechTask/Root/RootLogic.swift
+++ b/TechTask/Root/RootLogic.swift
@@ -1,0 +1,17 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import ComposableArchitecture
+
+@Reducer
+struct RootLogic: Reducer {
+  @ObservableState
+  struct State: Equatable {}
+
+  enum Action {}
+
+  var body: some ReducerOf<Self> {
+    Reduce<State, Action> { _, _ in
+      .none
+    }
+  }
+}

--- a/TechTask/Screen/ScreenA/ScreenA.swift
+++ b/TechTask/Screen/ScreenA/ScreenA.swift
@@ -1,0 +1,49 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import ComposableArchitecture
+import SwiftUI
+
+struct ScreenA: View {
+  let store: StoreOf<ScreenALogic>
+  var body: some View {
+    VStack(spacing: 10) {
+      Image(systemName: "globe")
+        .imageScale(.large)
+        .foregroundStyle(.tint)
+      Text("ScreenA")
+
+      VStack(spacing: 10) {
+        Spacer()
+        Button {
+          // TODO:
+        } label: {
+          Text("Show confirmation dialog")
+        }
+        Button {
+          // TODO:
+        } label: {
+          Text("Show alert")
+        }
+        Button {
+          // TODO:
+        } label: {
+          Text("Show bottom sheet")
+        }
+
+        Button {
+          // TODO:
+        } label: {
+          Text("Show full screen cover")
+        }
+      }
+    }
+    .padding()
+  }
+}
+
+#Preview {
+  ScreenA(store: Store(
+    initialState: ScreenALogic.State(),
+    reducer: { ScreenALogic() }
+  ))
+}

--- a/TechTask/Screen/ScreenA/ScreenALogic.swift
+++ b/TechTask/Screen/ScreenA/ScreenALogic.swift
@@ -1,0 +1,17 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import ComposableArchitecture
+
+@Reducer
+struct ScreenALogic: Reducer {
+  @ObservableState
+  struct State: Equatable {}
+
+  enum Action {}
+
+  var body: some ReducerOf<Self> {
+    Reduce<State, Action> { _, _ in
+      .none
+    }
+  }
+}

--- a/TechTask/Screen/ScreenB/ScreenB.swift
+++ b/TechTask/Screen/ScreenB/ScreenB.swift
@@ -1,0 +1,33 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import ComposableArchitecture
+import SwiftUI
+
+struct ScreenB: View {
+  let store: StoreOf<ScreenBLogic>
+  var body: some View {
+    VStack(spacing: 10) {
+      Image(systemName: "globe")
+        .imageScale(.large)
+        .foregroundStyle(.tint)
+      Text("ScreenB")
+
+      VStack(spacing: 10) {
+        Spacer()
+        Button {
+          // TODO:
+        } label: {
+          Text("Navigate to A then C")
+        }
+      }
+    }
+    .padding()
+  }
+}
+
+#Preview {
+  ScreenB(store: Store(
+    initialState: ScreenBLogic.State(),
+    reducer: { ScreenBLogic() }
+  ))
+}

--- a/TechTask/Screen/ScreenB/ScreenBLogic.swift
+++ b/TechTask/Screen/ScreenB/ScreenBLogic.swift
@@ -1,0 +1,17 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import ComposableArchitecture
+
+@Reducer
+struct ScreenBLogic: Reducer {
+  @ObservableState
+  struct State: Equatable {}
+
+  enum Action {}
+
+  var body: some ReducerOf<Self> {
+    Reduce<State, Action> { _, _ in
+      .none
+    }
+  }
+}

--- a/TechTask/Screen/ScreenC/ScreenC.swift
+++ b/TechTask/Screen/ScreenC/ScreenC.swift
@@ -1,0 +1,33 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import ComposableArchitecture
+import SwiftUI
+
+struct ScreenC: View {
+  let store: StoreOf<ScreenCLogic>
+  var body: some View {
+    VStack(spacing: 10) {
+      Image(systemName: "globe")
+        .imageScale(.large)
+        .foregroundStyle(.tint)
+      Text("ScreenC")
+
+      VStack(spacing: 10) {
+        Spacer()
+        Button {
+          // TODO:
+        } label: {
+          Text("Pop to root")
+        }
+      }
+    }
+    .padding()
+  }
+}
+
+#Preview {
+  ScreenC(store: Store(
+    initialState: ScreenCLogic.State(),
+    reducer: { ScreenCLogic() }
+  ))
+}

--- a/TechTask/Screen/ScreenC/ScreenCLogic.swift
+++ b/TechTask/Screen/ScreenC/ScreenCLogic.swift
@@ -1,0 +1,17 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import ComposableArchitecture
+
+@Reducer
+struct ScreenCLogic: Reducer {
+  @ObservableState
+  struct State: Equatable {}
+
+  enum Action {}
+
+  var body: some ReducerOf<Self> {
+    Reduce<State, Action> { _, _ in
+      .none
+    }
+  }
+}

--- a/TechTask/Shared/DummyBottomSheet/DummyBottomSheet.swift
+++ b/TechTask/Shared/DummyBottomSheet/DummyBottomSheet.swift
@@ -1,0 +1,24 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import ComposableArchitecture
+import SwiftUI
+
+struct DummyBottomSheet: View {
+  let store: StoreOf<DummyBottomSheetLogic>
+  var body: some View {
+    VStack(spacing: 10) {
+      Image(systemName: "globe")
+        .imageScale(.large)
+        .foregroundStyle(.tint)
+      Text("DummyBottomSheet")
+    }
+    .padding()
+  }
+}
+
+#Preview {
+  DummyBottomSheet(store: Store(
+    initialState: DummyBottomSheetLogic.State(),
+    reducer: { DummyBottomSheetLogic() }
+  ))
+}

--- a/TechTask/Shared/DummyBottomSheet/DummyBottomSheetLogic.swift
+++ b/TechTask/Shared/DummyBottomSheet/DummyBottomSheetLogic.swift
@@ -1,0 +1,17 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import ComposableArchitecture
+
+@Reducer
+struct DummyBottomSheetLogic: Reducer {
+  @ObservableState
+  struct State: Equatable {}
+
+  enum Action {}
+
+  var body: some ReducerOf<Self> {
+    Reduce<State, Action> { _, _ in
+      .none
+    }
+  }
+}

--- a/TechTask/TechTask.entitlements
+++ b/TechTask/TechTask.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/TechTaskTests/TechTaskTests.swift
+++ b/TechTaskTests/TechTaskTests.swift
@@ -1,0 +1,15 @@
+//  Copyright © 2025 BrightHR. All rights reserved.
+
+import Testing
+import ComposableArchitecture
+@testable import TCAExamples
+
+struct TCAExamplesTests {
+  
+  /// Add navigations tests
+  
+  @Test
+  func example() async throws {
+    
+  }
+}

--- a/TechTaskTests/TechTaskTests.swift
+++ b/TechTaskTests/TechTaskTests.swift
@@ -1,12 +1,10 @@
 //  Copyright © 2025 BrightHR. All rights reserved.
 
-import Testing
 import ComposableArchitecture
-@testable import TCAExamples
+@testable import TechTask
+import Testing
 
-struct TCAExamplesTests {
-  
-  /// Add navigations tests
+struct TechTaskTests {
   
   @Test
   func example() async throws {


### PR DESCRIPTION
This pull request introduces a new SwiftUI-based technical task project using The Composable Architecture (TCA). It includes updates to the project structure, implementation of foundational components, and setup for navigation and UI elements. Below is a summary of the most important changes:

### Project Setup and Structure:
* Updated `README.md` with a new task description, requirements, and evaluation criteria for implementing a SwiftUI app using TCA. This replaces the previous trivia app project description.
* Added `AppMain.swift` to define the app entry point with a `Root` view using TCA's `Store` and `Reducer`.
* Added an entitlement file (`TechTask.entitlements`) to enable app sandboxing and read-only access to user-selected files.

### Navigation and View Components:
* Implemented a `Root` view (`Root.swift`) with buttons for navigating to Screens A, B, and C.
* Added placeholder views and logic for `ScreenA`, `ScreenB`, and `ScreenC`, each with TCA reducers and TODOs for navigation and UI functionality. [[1]](diffhunk://#diff-db0cb7f03861e197c8f9cbcab3b9dd0dbdea7b451b236e9b850c9982a02119d7R1-R49) [[2]](diffhunk://#diff-bc7d91f238efc5db5994b2c52a43b96ef8078289758aef72a23eee25700a9f58R1-R17) [[3]](diffhunk://#diff-8f558bbc1ea8d5c5b2b9e1045ef7b62a94238e15b91285b738a459a6b7357766R1-R33) [[4]](diffhunk://#diff-028a47a94ff0bca3606fd6aeae9631e3329d61269e8587f66a1eece2777ac25eR1-R17) [[5]](diffhunk://#diff-5e04455494e5b66a23044959d89318c999885d387f5b5656629061bd247eebe4R1-R33) [[6]](diffhunk://#diff-0ff9795fb00c9c3e0223007b67855130c75c005e3b44ae6c032409648382bc40R1-R17)

### Shared Components:
* Added a `DummyBottomSheet` view and its corresponding logic as a shared component for bottom sheet presentations. [[1]](diffhunk://#diff-93ecab34e325f3dde58559e09afddff49851ef1fbeb3f6d2496584640a023d97R1-R24) [[2]](diffhunk://#diff-a393a7711270745b111de127828896eb1ea7053c905a6208f7e73f33fbedae12R1-R17)

### Assets and Configuration:
* Added `AccentColor.colorset` and `AppIcon.appiconset` to define app-wide color and icon assets. [[1]](diffhunk://#diff-1f25466f6e990b718342be76a8fadbd15a4d6b517bb4a3ba0e2db3f30d5544b9R1-R11) [[2]](diffhunk://#diff-ab450d1e5a8180fb00fa6f24694dae0039513289e2df72e80b0907f35fc07c9eR1-R85)
* Added `Contents.json` files for asset catalog organization.

### Testing:
* Introduced a basic test file (`TechTaskTests.swift`) with a placeholder for navigation-related tests using TCA.